### PR TITLE
Remove organization field from API

### DIFF
--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -124,11 +124,6 @@ func (h *AuthHandler) Login(c *gin.Context) {
 			LastSeen:    lastSeenStr,
 			CreatedAt:   user.CreatedAt.Format(time.RFC3339),
 		},
-		Organization: &models.OrganizationBrief{
-			ID:     user.Organization.ID.String(),
-			Name:   user.Organization.Name,
-			Domain: user.Organization.Domain,
-		},
 	}
 
 	c.JSON(http.StatusOK, response)
@@ -239,11 +234,6 @@ func (h *AuthHandler) ValidateToken(c *gin.Context) {
 			Status:      string(user.Status),
 			LastSeen:    lastSeenStr,
 			CreatedAt:   user.CreatedAt.Format(time.RFC3339),
-		},
-		Organization: &models.OrganizationBrief{
-			ID:     user.Organization.ID.String(),
-			Name:   user.Organization.Name,
-			Domain: user.Organization.Domain,
 		},
 	}
 

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -84,11 +84,6 @@ func (h *UserHandler) GetProfile(c *gin.Context) {
 			Status:      string(user.Status),
 			LastSeen:    lastSeenStr,
 			CreatedAt:   user.CreatedAt.Format(time.RFC3339),
-			Organization: models.OrganizationBrief{
-				ID:     user.Organization.ID.String(),
-				Name:   user.Organization.Name,
-				Domain: user.Organization.Domain,
-			},
 			Preferences: models.UserPreferences{
 				SelectedAlgorithms: models.AlgorithmSelection{
 					Asymmetric: "NTRU",    // Default values

--- a/internal/models/dto.go
+++ b/internal/models/dto.go
@@ -65,11 +65,10 @@ type ServerPolicies struct {
 
 // Auth DTOs
 type RegisterRequest struct {
-	Username           string `json:"username" binding:"required,email"`
-	Password           string `json:"password" binding:"required,min=8"`
-	DisplayName        string `json:"display_name" binding:"required"`
-	Email              string `json:"email" binding:"required,email"`
-	OrganizationDomain string `json:"organization_domain" binding:"required"`
+	Username    string `json:"username" binding:"required,email"`
+	Password    string `json:"password" binding:"required,min=8"`
+	DisplayName string `json:"display_name" binding:"required"`
+	Email       string `json:"email" binding:"required,email"`
 }
 
 type LoginRequest struct {
@@ -78,12 +77,11 @@ type LoginRequest struct {
 }
 
 type AuthResponse struct {
-	Success        bool               `json:"success"`
-	Message        string             `json:"message"`
-	Token          string             `json:"token,omitempty"`
-	TokenExpiresAt string             `json:"token_expires_at,omitempty"`
-	User           UserInfo           `json:"user"`
-	Organization   *OrganizationBrief `json:"organization,omitempty"`
+	Success        bool     `json:"success"`
+	Message        string   `json:"message"`
+	Token          string   `json:"token,omitempty"`
+	TokenExpiresAt string   `json:"token_expires_at,omitempty"`
+	User           UserInfo `json:"user"`
 }
 
 type UserInfo struct {
@@ -96,12 +94,6 @@ type UserInfo struct {
 	CreatedAt   string  `json:"created_at"`
 }
 
-type OrganizationBrief struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	Domain string `json:"domain"`
-}
-
 // User DTOs
 type UserProfileResponse struct {
 	Success bool                `json:"success"`
@@ -109,15 +101,14 @@ type UserProfileResponse struct {
 }
 
 type DetailedUserProfile struct {
-	ID           string            `json:"id"`
-	Username     string            `json:"username"`
-	DisplayName  string            `json:"display_name"`
-	Email        string            `json:"email"`
-	Status       string            `json:"status"`
-	LastSeen     *string           `json:"last_seen"`
-	CreatedAt    string            `json:"created_at"`
-	Organization OrganizationBrief `json:"organization"`
-	Preferences  UserPreferences   `json:"preferences"`
+	ID          string          `json:"id"`
+	Username    string          `json:"username"`
+	DisplayName string          `json:"display_name"`
+	Email       string          `json:"email"`
+	Status      string          `json:"status"`
+	LastSeen    *string         `json:"last_seen"`
+	CreatedAt   string          `json:"created_at"`
+	Preferences UserPreferences `json:"preferences"`
 }
 
 type UpdateProfileRequest struct {

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -43,12 +43,9 @@ func (s *UserService) CreateUser(req *models.RegisterRequest) (*models.User, err
 		return nil, err
 	}
 
-	// Check if organization domain matches our server's organization
-	org, err := s.orgService.GetOrganizationByDomain(req.OrganizationDomain)
+	// Get default organization from config
+	org, err := s.orgService.GetOrganizationByDomain(s.orgService.config.App.Organization.Domain)
 	if err != nil {
-		if errors.Is(err, ErrOrganizationNotFound) {
-			return nil, ErrOrganizationNotFound
-		}
 		return nil, fmt.Errorf("failed to get organization: %w", err)
 	}
 
@@ -351,10 +348,6 @@ func (s *UserService) validateRegisterRequest(req *models.RegisterRequest) error
 
 	if req.Email == "" {
 		return errors.New("email is required")
-	}
-
-	if req.OrganizationDomain == "" {
-		return errors.New("organization domain is required")
 	}
 
 	// Basic email validation


### PR DESCRIPTION
## Summary
- rely on config for organization info
- drop organization domain from registration request
- stop including organization data in auth/user responses

## Testing
- `go vet ./...` *(fails: network access blocked)*
- `go fmt ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ea073b70c83239554d12971a84646