### PR TITLE
Remove redundant username field

### DIFF
--- a/internal/api/admin_handler.go
+++ b/internal/api/admin_handler.go
@@ -104,7 +104,7 @@ func (h *AdminHandler) GetAllUsers(c *gin.Context) {
 	validSorts := map[string]bool{
 		"created_at":   true,
 		"last_seen":    true,
-		"username":     true,
+		"email":        true,
 		"status":       true,
 		"display_name": true,
 	}

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -62,7 +62,6 @@ func (h *AuthHandler) Register(c *gin.Context) {
 		Message: "Пользователь успешно зарегистрирован",
 		User: models.UserInfo{
 			ID:          user.ID.String(),
-			Username:    user.Username,
 			DisplayName: user.DisplayName,
 			Email:       user.Email,
 			Status:      string(user.Status),
@@ -117,7 +116,6 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		TokenExpiresAt: expiresAt.Format(time.RFC3339),
 		User: models.UserInfo{
 			ID:          user.ID.String(),
-			Username:    user.Username,
 			DisplayName: user.DisplayName,
 			Email:       user.Email,
 			Status:      string(user.Status),
@@ -228,7 +226,6 @@ func (h *AuthHandler) ValidateToken(c *gin.Context) {
 		Message: "Token is valid",
 		User: models.UserInfo{
 			ID:          user.ID.String(),
-			Username:    user.Username,
 			DisplayName: user.DisplayName,
 			Email:       user.Email,
 			Status:      string(user.Status),

--- a/internal/api/message_handler.go
+++ b/internal/api/message_handler.go
@@ -162,8 +162,6 @@ func (h *MessageHandler) GetPendingMessages(c *gin.Context) {
 		senderName := "Unknown"
 		if msg.Sender.DisplayName != "" {
 			senderName = msg.Sender.DisplayName
-		} else if msg.Sender.Username != "" {
-			senderName = msg.Sender.Username
 		}
 
 		responseMsg := models.PendingMessage{
@@ -298,13 +296,13 @@ func (h *MessageHandler) CreateChat(c *gin.Context) {
 	participants := []models.UserInfo{
 		{
 			ID:          chatMetadata.User1.ID.String(),
-			Username:    chatMetadata.User1.Username,
 			DisplayName: chatMetadata.User1.DisplayName,
+			Email:       chatMetadata.User1.Email,
 		},
 		{
 			ID:          chatMetadata.User2.ID.String(),
-			Username:    chatMetadata.User2.Username,
 			DisplayName: chatMetadata.User2.DisplayName,
+			Email:       chatMetadata.User2.Email,
 		},
 	}
 
@@ -438,13 +436,13 @@ func (h *MessageHandler) GetUserChats(c *gin.Context) {
 		participants := []models.UserInfo{
 			{
 				ID:          chat.User1.ID.String(),
-				Username:    chat.User1.Username,
 				DisplayName: chat.User1.DisplayName,
+				Email:       chat.User1.Email,
 			},
 			{
 				ID:          chat.User2.ID.String(),
-				Username:    chat.User2.Username,
 				DisplayName: chat.User2.DisplayName,
+				Email:       chat.User2.Email,
 			},
 		}
 

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -78,7 +78,6 @@ func (h *UserHandler) GetProfile(c *gin.Context) {
 		Success: true,
 		User: models.DetailedUserProfile{
 			ID:          user.ID.String(),
-			Username:    user.Username,
 			DisplayName: user.DisplayName,
 			Email:       user.Email,
 			Status:      string(user.Status),
@@ -151,7 +150,6 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 		Message: "Профиль успешно обновлен",
 		Data: map[string]interface{}{
 			"id":           updatedUser.ID.String(),
-			"username":     updatedUser.Username,
 			"display_name": updatedUser.DisplayName,
 			"email":        updatedUser.Email,
 			"status":       string(updatedUser.Status),
@@ -226,7 +224,6 @@ func (h *UserHandler) SearchUsers(c *gin.Context) {
 
 		searchResults = append(searchResults, models.SearchUserResult{
 			ID:            user.ID.String(),
-			Username:      user.Username,
 			DisplayName:   user.DisplayName,
 			Status:        string(user.Status),
 			LastSeen:      lastSeenStr,
@@ -302,7 +299,6 @@ func (h *UserHandler) GetUserStatus(c *gin.Context) {
 		Success: true,
 		User: models.UserStatusInfo{
 			ID:             targetUser.ID.String(),
-			Username:       targetUser.Username,
 			DisplayName:    targetUser.DisplayName,
 			Status:         string(targetUser.Status),
 			LastSeen:       lastSeenStr,
@@ -409,7 +405,6 @@ func (h *UserHandler) GetOnlineUsers(c *gin.Context) {
 
 			onlineUsers = append(onlineUsers, models.SearchUserResult{
 				ID:            user.ID.String(),
-				Username:      user.Username,
 				DisplayName:   user.DisplayName,
 				Status:        string(user.Status),
 				LastSeen:      lastSeenStr,

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -25,8 +25,8 @@ var (
 
 // JWTClaims represents the claims in a JWT token
 type JWTClaims struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
+	UserID string `json:"user_id"`
+	Email  string `json:"email"`
 	jwt.RegisteredClaims
 }
 
@@ -53,8 +53,8 @@ func (j *JWTManager) GenerateToken(user *models.User) (string, time.Time, error)
 	expiresAt := time.Now().Add(j.expiryTime)
 
 	claims := &JWTClaims{
-		UserID:   user.ID.String(),
-		Username: user.Username,
+		UserID: user.ID.String(),
+		Email:  user.Email,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(expiresAt),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -236,7 +236,7 @@ func (a *AuthService) AuthMiddleware() gin.HandlerFunc {
 
 		// Store claims in context for use in handlers
 		c.Set("user_id", claims.UserID)
-		c.Set("username", claims.Username)
+		c.Set("email", claims.Email)
 		c.Set("claims", claims)
 
 		c.Next()
@@ -262,7 +262,7 @@ func (a *AuthService) OptionalAuthMiddleware() gin.HandlerFunc {
 
 		// Store claims in context if valid
 		c.Set("user_id", claims.UserID)
-		c.Set("username", claims.Username)
+		c.Set("email", claims.Email)
 		c.Set("claims", claims)
 
 		c.Next()
@@ -289,17 +289,17 @@ func GetUserIDFromContext(c *gin.Context) (uuid.UUID, error) {
 	return userID, nil
 }
 
-// GetUsernameFromContext extracts username from Gin context
-func GetUsernameFromContext(c *gin.Context) (string, error) {
-	username, exists := c.Get("username")
+// GetEmailFromContext extracts user email from Gin context
+func GetEmailFromContext(c *gin.Context) (string, error) {
+	email, exists := c.Get("email")
 	if !exists {
-		return "", errors.New("username not found in context")
+		return "", errors.New("email not found in context")
 	}
 
-	usernameStr, ok := username.(string)
+	emailStr, ok := email.(string)
 	if !ok {
-		return "", errors.New("invalid username format in context")
+		return "", errors.New("invalid email format in context")
 	}
 
-	return usernameStr, nil
+	return emailStr, nil
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -97,7 +97,7 @@ func (d *Database) AutoMigrate() error {
 func (d *Database) createIndexes() error {
 	indexes := []string{
 		"CREATE INDEX IF NOT EXISTS idx_users_status ON users(status)",
-		"CREATE INDEX IF NOT EXISTS idx_users_username_lower ON users(LOWER(username))",
+		"CREATE INDEX IF NOT EXISTS idx_users_email_lower ON users(LOWER(email))",
 		"CREATE INDEX IF NOT EXISTS idx_users_display_name_gin ON users USING gin(to_tsvector('english', display_name))",
 		"CREATE INDEX IF NOT EXISTS idx_active_connections_user ON active_connections(user_id)",
 		"CREATE INDEX IF NOT EXISTS idx_active_connections_last_heartbeat ON active_connections(last_heartbeat)",

--- a/internal/models/dto.go
+++ b/internal/models/dto.go
@@ -63,14 +63,13 @@ type ServerPolicies struct {
 
 // Auth DTOs
 type RegisterRequest struct {
-	Username    string `json:"username" binding:"required,email"`
 	Password    string `json:"password" binding:"required,min=8"`
 	DisplayName string `json:"display_name" binding:"required"`
 	Email       string `json:"email" binding:"required,email"`
 }
 
 type LoginRequest struct {
-	Username string `json:"username" binding:"required"`
+	Email    string `json:"email" binding:"required,email"`
 	Password string `json:"password" binding:"required"`
 }
 
@@ -84,7 +83,6 @@ type AuthResponse struct {
 
 type UserInfo struct {
 	ID          string  `json:"id"`
-	Username    string  `json:"username"`
 	DisplayName string  `json:"display_name"`
 	Email       string  `json:"email"`
 	Status      string  `json:"status"`
@@ -100,7 +98,6 @@ type UserProfileResponse struct {
 
 type DetailedUserProfile struct {
 	ID          string          `json:"id"`
-	Username    string          `json:"username"`
 	DisplayName string          `json:"display_name"`
 	Email       string          `json:"email"`
 	Status      string          `json:"status"`
@@ -126,7 +123,6 @@ type UserSearchResponse struct {
 
 type SearchUserResult struct {
 	ID            string  `json:"id"`
-	Username      string  `json:"username"`
 	DisplayName   string  `json:"display_name"`
 	Status        string  `json:"status"`
 	LastSeen      *string `json:"last_seen"`
@@ -140,7 +136,6 @@ type UserStatusResponse struct {
 
 type UserStatusInfo struct {
 	ID             string         `json:"id"`
-	Username       string         `json:"username"`
 	DisplayName    string         `json:"display_name"`
 	Status         string         `json:"status"`
 	LastSeen       *string        `json:"last_seen"`
@@ -259,7 +254,6 @@ type AdminUsersResponse struct {
 
 type AdminUserInfo struct {
 	ID                string  `json:"id"`
-	Username          string  `json:"username"`
 	DisplayName       string  `json:"display_name"`
 	Email             string  `json:"email"`
 	Status            string  `json:"status"`
@@ -285,7 +279,6 @@ type BlockUserResponse struct {
 
 type BlockedUserInfo struct {
 	ID           string  `json:"id"`
-	Username     string  `json:"username"`
 	BlockedUntil *string `json:"blocked_until"`
 	Reason       string  `json:"reason"`
 	BlockedBy    string  `json:"blocked_by"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -19,8 +19,7 @@ const (
 // User represents a user entity
 type User struct {
 	ID           uuid.UUID  `json:"id" gorm:"type:uuid;primary_key;default:gen_random_uuid()"`
-	Username     string     `json:"username" gorm:"type:varchar(255);unique;not null"`
-	Email        string     `json:"email" gorm:"type:varchar(255)"`
+	Email        string     `json:"email" gorm:"type:varchar(255);unique;not null"`
 	PasswordHash string     `json:"-" gorm:"type:varchar(255);not null"`
 	DisplayName  string     `json:"display_name" gorm:"type:varchar(255)"`
 	Status       UserStatus `json:"status" gorm:"type:varchar(30);default:'offline_disconnected'"`

--- a/internal/services/admin_service.go
+++ b/internal/services/admin_service.go
@@ -184,7 +184,6 @@ func (s *AdminService) GetAllUsersForAdmin(limit, offset int, statusFilter, sort
 
 		adminUser := models.AdminUserInfo{
 			ID:                user.ID.String(),
-			Username:          user.Username,
 			DisplayName:       user.DisplayName,
 			Email:             user.Email,
 			Status:            string(user.Status),
@@ -248,7 +247,6 @@ func (s *AdminService) BlockUserByAdmin(userID, adminID uuid.UUID, req *models.B
 
 	blockedUserInfo := &models.BlockedUserInfo{
 		ID:           blockedUser.User.ID.String(),
-		Username:     blockedUser.User.Username,
 		BlockedUntil: blockedUntilStr,
 		Reason:       blockedUser.Reason,
 		BlockedBy:    blockedUser.AdminUser.ID.String(),
@@ -291,7 +289,6 @@ func (s *AdminService) GetBlockedUsers() ([]models.BlockedUserInfo, error) {
 
 		info := models.BlockedUserInfo{
 			ID:           blocked.User.ID.String(),
-			Username:     blocked.User.Username,
 			BlockedUntil: blockedUntilStr,
 			Reason:       blocked.Reason,
 			BlockedBy:    blocked.AdminUser.ID.String(),
@@ -369,7 +366,7 @@ func (s *AdminService) IsUserAdmin(userID uuid.UUID) (bool, error) {
 		return false, err
 	}
 
-	// Simple admin check - first registered user or specific username
+	// Simple admin check - first registered user
 	var firstUser models.User
 	if err := s.db.Order("created_at ASC").First(&firstUser).Error; err != nil {
 		return false, err

--- a/internal/websocket/client.go
+++ b/internal/websocket/client.go
@@ -324,7 +324,7 @@ func (c *Client) GetInfo() map[string]interface{} {
 	return map[string]interface{}{
 		"id":             c.ID,
 		"user_id":        c.UserID.String(),
-		"username":       c.Username,
+		"email":          c.Email,
 		"ip_address":     c.IPAddress,
 		"user_agent":     c.UserAgent,
 		"last_heartbeat": c.GetLastHeartbeat().Format(time.RFC3339),

--- a/internal/websocket/manager.go
+++ b/internal/websocket/manager.go
@@ -32,7 +32,7 @@ var upgrader = websocket.Upgrader{
 type Client struct {
 	ID            string
 	UserID        uuid.UUID
-	Username      string
+	Email         string
 	Connection    *websocket.Conn
 	Send          chan []byte
 	Manager       *Manager
@@ -145,7 +145,7 @@ func (m *Manager) HandleWebSocket(c *gin.Context) {
 	client := &Client{
 		ID:            uuid.New().String(),
 		UserID:        userID,
-		Username:      claims.Username,
+		Email:         claims.Email,
 		Connection:    conn,
 		Send:          make(chan []byte, 256),
 		Manager:       m,
@@ -198,7 +198,7 @@ func (m *Manager) registerClient(client *Client) {
 	}
 	m.userClients[client.UserID][client.ID] = client
 
-	log.Printf("Client registered: %s for user %s", client.ID, client.Username)
+	log.Printf("Client registered: %s for user %s", client.ID, client.Email)
 
 	// Update user status to online
 	if err := m.userService.UpdateUserStatus(client.UserID, models.StatusOnline); err != nil {
@@ -264,7 +264,7 @@ func (m *Manager) unregisterClient(client *Client) {
 	// Remove connection from database
 	m.removeConnection(client)
 
-	log.Printf("Client unregistered: %s for user %s", client.ID, client.Username)
+	log.Printf("Client unregistered: %s for user %s", client.ID, client.Email)
 }
 
 // SendToUser sends a message to a specific user

--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -9,8 +9,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 -- Users table
 CREATE TABLE IF NOT EXISTS users (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    username VARCHAR(255) UNIQUE NOT NULL,
-    email VARCHAR(255),
+    email VARCHAR(255) UNIQUE NOT NULL,
     password_hash VARCHAR(255) NOT NULL,
     display_name VARCHAR(255),
     status VARCHAR(30) DEFAULT 'offline_disconnected',
@@ -19,8 +18,7 @@ CREATE TABLE IF NOT EXISTS users (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     is_blocked BOOLEAN DEFAULT FALSE,
     
-    CONSTRAINT valid_status CHECK (status IN ('online', 'offline_connected', 'offline_disconnected')),
-    CONSTRAINT valid_username_format CHECK (username ~ '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$')
+    CONSTRAINT valid_status CHECK (status IN ('online', 'offline_connected', 'offline_disconnected'))
 );
 
 -- Active WebSocket connections table
@@ -83,7 +81,7 @@ CREATE TABLE IF NOT EXISTS blocked_users (
 
 -- Create indexes for performance
 CREATE INDEX IF NOT EXISTS idx_users_status ON users(status);
-CREATE INDEX IF NOT EXISTS idx_users_username_lower ON users(LOWER(username));
+CREATE INDEX IF NOT EXISTS idx_users_email_lower ON users(LOWER(email));
 CREATE INDEX IF NOT EXISTS idx_users_display_name_gin ON users USING gin(to_tsvector('english', display_name));
 
 CREATE INDEX IF NOT EXISTS idx_active_connections_user ON active_connections(user_id);


### PR DESCRIPTION
## Summary
- use only `email` for authentication and registration
- drop `username` from DTOs, models, and services
- update JWT claims and WebSocket client info
- adjust migrations and DB indexes

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6862697fc0d08323800ea0b1b252b310